### PR TITLE
fix(host-ui): responsive tv layout, code sticker, squarcles, hamburger styling

### DIFF
--- a/css/3-host.css
+++ b/css/3-host.css
@@ -8,7 +8,7 @@
     padding: var(--space-lg);
     background: linear-gradient(135deg, var(--color-bg-darker) 0%, #1a1f3a 100%);
     color: var(--color-text-light);
-    MARGIN: AUTO;
+    margin: auto;
     width: calc(100% - 4em);
 }
 
@@ -336,6 +336,7 @@
     border: 1px solid rgba(139, 92, 246, 0.2);
     max-height: 200px;
     overflow-y: auto;
+    justify-content: center;
 }
 
 .btn-remove-player {
@@ -480,6 +481,41 @@
     }
 }
 
+/* NEW: Better mid breakpoint (avoids unusable layout between 1400 and 1024) */
+@media (max-width: 1280px) {
+    .tv-layout {
+        grid-template-columns: 180px 1fr;
+        grid-template-rows: auto 1fr auto auto;
+        height: auto;
+    }
+
+    .ranking-panel {
+        grid-row: 2;
+        grid-column: 1;
+        max-height: none;
+    }
+
+    .center-panel {
+        grid-row: 2;
+        grid-column: 2;
+        padding: var(--space-2xl);
+        gap: var(--space-xl);
+    }
+
+    .top-words-panel {
+        grid-row: 3;
+        grid-column: 1 / -1;
+        max-height: 160px;
+    }
+
+    .players-grid,
+    .results-panel {
+        grid-row: 4;
+        grid-column: 1 / -1;
+        max-height: 220px;
+    }
+}
+
 @media (max-width: 1024px) {
     .tv-layout {
         grid-template-columns: 1fr;
@@ -488,14 +524,28 @@
         height: auto;
     }
 
-    .ranking-panel,
-    .top-words-panel {
+    /* FIX: avoid overlap by explicitly assigning rows */
+    .ranking-panel {
+        grid-row: 2;
         grid-column: 1;
-        max-height: 120px;
+        max-height: 140px;
     }
 
     .center-panel {
         grid-row: 3;
+        grid-column: 1;
+        padding: var(--space-2xl);
+    }
+
+    .top-words-panel {
+        grid-row: 4;
+        grid-column: 1;
+        max-height: 140px;
+    }
+
+    .players-grid,
+    .results-panel {
+        grid-row: 5;
         grid-column: 1;
     }
 
@@ -534,7 +584,7 @@
 
     .ranking-panel,
     .top-words-panel {
-        max-height: 100px;
+        max-height: 120px;
         padding: var(--space-md);
     }
 
@@ -552,7 +602,7 @@
     }
 
     .players-grid {
-        max-height: 150px;
+        max-height: 180px;
         gap: var(--space-md);
         padding: var(--space-md);
     }
@@ -600,7 +650,7 @@
     .ranking-panel,
     .top-words-panel,
     .results-panel {
-        max-height: 80px;
+        max-height: 100px;
         padding: var(--space-md);
         gap: var(--space-sm);
     }
@@ -637,7 +687,7 @@
 
     .players-grid {
         grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-        max-height: 120px;
+        max-height: 160px;
         gap: var(--space-md);
         padding: var(--space-md);
     }

--- a/css/4-components.css
+++ b/css/4-components.css
@@ -153,6 +153,7 @@
 .player-squarcle {
     position: relative;
     width: 100%;
+    max-width: 170px;
     aspect-ratio: 1;
     border-radius: var(--radius-card);
     display: flex;
@@ -162,20 +163,30 @@
     gap: 8px;
     padding: 10px;
     backdrop-filter: blur(8px);
-    border: 2px solid rgba(255, 255, 255, 0.1);
+    border: 2px solid rgba(255, 255, 255, 0.16);
     transition: all 0.3s ease;
     cursor: default;
+    justify-self: center;
+    overflow: hidden;
+}
+
+.player-squarcle::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 30% 20%, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0) 55%);
+    pointer-events: none;
 }
 
 .player-squarcle:hover {
     transform: translateY(-4px);
-    border-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.24);
 }
 
 .player-initial {
     font-size: 32px;
     font-weight: 700;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(255, 255, 255, 0.92);
     text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
@@ -186,7 +197,7 @@
 .player-name-label {
     font-size: 12px;
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.85);
     text-align: center;
     word-break: break-word;
     white-space: nowrap;
@@ -213,6 +224,7 @@
     justify-content: center;
     opacity: 0;
     transition: all 0.3s ease;
+    z-index: 2;
 }
 
 .player-squarcle:hover .btn-remove-player {
@@ -279,9 +291,9 @@
     left: 20px;
     width: 50px;
     height: 50px;
-    background: rgba(34, 197, 94, 0.1);
-    border: 2px solid rgba(34, 197, 94, 0.3);
-    border-radius: 8px;
+    background: rgba(46, 0, 78, 0.88);
+    border: 2px solid rgba(0, 240, 255, 0.6);
+    border-radius: 12px;
     cursor: pointer;
     display: flex;
     flex-direction: column;
@@ -290,18 +302,21 @@
     gap: 6px;
     transition: all 0.3s ease;
     z-index: 100;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 0 22px rgba(0, 240, 255, 0.25), var(--sombra-dura);
 }
 
 .btn-hamburger:hover {
-    background: rgba(34, 197, 94, 0.2);
-    border-color: rgba(34, 197, 94, 0.6);
-    box-shadow: 0 0 15px rgba(34, 197, 94, 0.2);
+    background: rgba(46, 0, 78, 0.95);
+    border-color: rgba(0, 240, 255, 0.85);
+    box-shadow: 0 0 34px rgba(0, 240, 255, 0.32), var(--sombra-dura);
+    transform: translateY(-2px);
 }
 
 .hamburger-line {
     width: 24px;
     height: 3px;
-    background: rgba(199, 210, 254, 0.8);
+    background: rgba(199, 210, 254, 0.92);
     border-radius: 2px;
     transition: all 0.3s ease;
 }
@@ -310,24 +325,25 @@
     position: fixed;
     bottom: 80px;
     left: 20px;
-    background: rgba(15, 23, 42, 0.95);
-    border: 2px solid rgba(34, 197, 94, 0.3);
-    border-radius: 12px;
-    min-width: 200px;
-    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+    background: rgba(46, 0, 78, 0.92);
+    border: 2px solid rgba(0, 240, 255, 0.55);
+    border-radius: 16px;
+    min-width: 220px;
+    box-shadow: 0 0 40px rgba(0, 240, 255, 0.18), var(--sombra-dura);
     z-index: 99;
     overflow: hidden;
     animation: slideDown 0.3s ease-out;
+    backdrop-filter: blur(10px);
 }
 
 .hamburger-header {
     padding: 12px 16px;
-    font-weight: 700;
-    color: #86efac;
-    font-size: 14px;
+    font-weight: 800;
+    color: var(--color-accent-amber);
+    font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 1px;
-    border-bottom: 1px solid rgba(34, 197, 94, 0.2);
+    border-bottom: 1px solid rgba(0, 240, 255, 0.22);
 }
 
 .hamburger-option {
@@ -336,10 +352,10 @@
     padding: 12px 16px;
     background: none;
     border: none;
-    border-bottom: 1px solid rgba(139, 92, 246, 0.1);
-    color: rgba(199, 210, 254, 0.9);
+    border-bottom: 1px solid rgba(0, 240, 255, 0.10);
+    color: rgba(199, 210, 254, 0.92);
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 600;
     cursor: pointer;
     text-align: left;
     transition: all 0.2s ease;
@@ -351,28 +367,28 @@
 }
 
 .hamburger-option:hover {
-    background: rgba(139, 92, 246, 0.15);
-    color: #86efac;
+    background: rgba(0, 240, 255, 0.10);
+    color: rgba(255, 255, 255, 0.95);
     padding-left: 20px;
 }
 
 .hamburger-option.hamburger-danger {
-    color: rgba(239, 68, 68, 0.9);
+    color: rgba(239, 68, 68, 0.95);
 }
 
 .hamburger-option.hamburger-danger:hover {
-    background: rgba(239, 68, 68, 0.15);
+    background: rgba(239, 68, 68, 0.14);
     color: #fca5a5;
 }
 
 .hamburger-option.hamburger-home {
-    border-top: 1px solid rgba(34, 197, 94, 0.2);
+    border-top: 1px solid rgba(0, 240, 255, 0.18);
     margin-top: 4px;
-    color: #86efac;
+    color: rgba(0, 240, 255, 0.92);
 }
 
 .hamburger-option.hamburger-home:hover {
-    background: rgba(34, 197, 94, 0.15);
+    background: rgba(0, 240, 255, 0.12);
 }
 
 @keyframes slideDown {


### PR DESCRIPTION
## Objetivo
Corregir problemas de UI actuales en Host:
- Código de sala no visible (code-sticker-value) por mismatch de IDs.
- Layout TV inusable debajo de 1400px (superposición en 1024px).
- Player squarcles gigantes cuando hay pocos jugadores.
- Hamburguesa con estilo distinto al modal.

## Cambios
### JS
- `js/host-manager.js`: soporta `#code-sticker-value`/`#code-sticker-floating` y mantiene fallback a `#game-code-tv`.
- Copy-to-clipboard ahora copia el código visible.

### CSS
- `css/3-host.css`: agrega breakpoint 1280px y fija grid-rows en 1024px para evitar overlap (ranking/topwords/players/results).
- `css/4-components.css`:
  - `player-squarcle` con `max-width` y centering para evitar que se estire a pantalla completa.
  - Hamburguesa y menú con look consistente con `modal-content`.

## Testing
- Host: 1920 / 1400 / 1280 / 1024 / 768 / 480.
- Verificar que el código de sala aparece en el sticker amarillo y se copia al click.
- Verificar que ranking/topwords no se pisan en 1024.
- Verificar que con 1-2 jugadores los squarcles quedan como tarjetas, no como rectángulos gigantes.