### PR TITLE
refactor(storage): centralize host session localStorage (Phase 1)

### DIFF
--- a/js/create-game-modal.js
+++ b/js/create-game-modal.js
@@ -332,13 +332,12 @@ class CreateGameModal {
             const gameId = result.game_id;
             console.log('✅ Juego creado:', gameId);
             
-            // Guardar en localStorage
-            localStorage.setItem('hostGameCode', gameId);
-            localStorage.setItem('gameId', gameId);
-            localStorage.setItem('isHost', 'true');
-            
-            // FIX: Guardar categoría para persistencia
-            localStorage.setItem('gameCategory', category);
+            // Guardar en localStorage (FASE 1: centralizado)
+            StorageManager.set(StorageKeys.HOST_GAME_CODE, gameId);
+            StorageManager.set(StorageKeys.GAME_ID, gameId);
+            StorageManager.set(StorageKeys.IS_HOST, 'true');
+            StorageManager.set(StorageKeys.GAME_CATEGORY, category);
+
             console.log('📋 Código y categoría guardados:', gameId, category);
             
             this.showMessage('✅ Partida creada. Inicializando...', 'success');

--- a/js/host-hamburger-menu.js
+++ b/js/host-hamburger-menu.js
@@ -92,10 +92,7 @@ class HostHamburgerMenu {
      * Si no hay sesión: mostrar modal de crear
      */
     checkActiveSession() {
-        const gameCode = localStorage.getItem('hostGameCode');
-        const isHost = localStorage.getItem('isHost');
-        
-        this.hasActiveSession = !!(gameCode && isHost === 'true');
+        this.hasActiveSession = StorageManager.isHostSessionActive();
         
         if (!this.hasActiveSession && this.modalCreateGame) {
             // Mostrar modal de crear si no hay sesión
@@ -169,11 +166,8 @@ class HostHamburgerMenu {
         this.close();
         
         if (confirm('¿Estas seguro de que quieres empezar una nueva partida? Se perdera el juego actual.')) {
-            // Limpiar localStorage
-            localStorage.removeItem('hostGameCode');
-            localStorage.removeItem('gameId');
-            localStorage.removeItem('isHost');
-            localStorage.removeItem('gameCategory');
+            // Limpiar localStorage (FASE 1: centralizado)
+            StorageManager.clearHostSession();
             
             // Recargar
             location.reload();
@@ -206,11 +200,8 @@ class HostHamburgerMenu {
         this.close();
         
         if (confirm('¿Estas seguro de que quieres terminar la partida? No se puede deshacer.')) {
-            // Limpiar localStorage
-            localStorage.removeItem('hostGameCode');
-            localStorage.removeItem('gameId');
-            localStorage.removeItem('isHost');
-            localStorage.removeItem('gameCategory');
+            // Limpiar localStorage (FASE 1: centralizado)
+            StorageManager.clearHostSession();
             
             // Ir al inicio
             location.href = './index.html';


### PR DESCRIPTION
## Objetivo
Centralizar el manejo de `localStorage` para el host en una única API (Fase 1), reduciendo duplicación y evitando inconsistencias.

## Cambios
- Se agregan `StorageKeys` y `StorageManager` en `js/shared-utils.js`.
- Se mantienen wrappers legacy `setLocalStorage()`, `getLocalStorage()` y `clearGameSession()` para no romper código existente.
- `js/create-game-modal.js`: reemplaza `localStorage.setItem(...)` por `StorageManager.set(...)`.
- `js/host-hamburger-menu.js`: reemplaza lecturas/eliminaciones de sesión por `StorageManager` (`isHostSessionActive()`, `clearHostSession()`).

## Notas de compatibilidad
- `StorageManager.get()` solo parsea JSON cuando el valor comienza con `{` o `[` para evitar que strings como `'true'` se conviertan a boolean `true` y rompan comparaciones existentes.

## Testing manual sugerido
- Host: Crear partida desde modal → verifica que el código se guarda y la UI sigue igual.
- Refresh en host con sesión activa → menú hamburguesa visible.
- New Game / Terminate → limpia storage y vuelve a crear partida sin residuos.

Closes: #25 (Phase 1)