### PR TITLE
Fix: host blank screen after create game (sync html session classes)

### DIFF
--- a/js/host-manager.js
+++ b/js/host-manager.js
@@ -24,6 +24,18 @@ function determineUIState() {
     const gameCode = StorageManager.get(StorageKeys.HOST_GAME_CODE);
     
     console.log(`📋 determineUIState() - Session: ${hasSession}, Code: ${gameCode || 'none'}`);
+
+    // CRÍTICO: sincronizar las clases del <html>.
+    // host.html usa .no-session/.has-session para ocultar/mostrar .session-only/.nosession-only
+    // y esas reglas tienen !important; si no se actualizan, la UI puede quedar "en blanco".
+    const root = document.documentElement;
+    if (hasSession && gameCode) {
+        root.classList.add('has-session');
+        root.classList.remove('no-session');
+    } else {
+        root.classList.add('no-session');
+        root.classList.remove('has-session');
+    }
     
     const modalCreate = document.getElementById('modal-create-game');
     const gameScreen = document.getElementById('game-screen');


### PR DESCRIPTION
## Problema
Al crear una partida desde `host.html`, el modal se oculta pero la pantalla queda vacía.

## Causa raíz
`host.html` usa clases en `<html>` (`.no-session` / `.has-session`) para ocultar/mostrar elementos `.session-only` / `.nosession-only` con reglas `!important`. Cuando se crea la partida, `determineUIState()` mostraba elementos por `style.display`, pero no actualizaba esas clases, por lo que la UI seguía oculta.

## Fix
- Sincroniza las clases del `<html>` dentro de `determineUIState()`.

## Cómo probar
1. Abrir `/host.html`.
2. Crear una partida.
3. Verificar que aparezca `game-screen` (código de sala, header TV, side panel, players container) en lugar de quedar en blanco.

